### PR TITLE
qemu-m68k: fix '-strace' not to accept arguments

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -4174,7 +4174,7 @@ static const struct qemu_argument arg_table[] = {
      "pagesize",   "set the host page size to 'pagesize'"},
     {"singlestep", "QEMU_SINGLESTEP",  false, handle_arg_singlestep,
      "",           "run in singlestep mode"},
-    {"strace",     "QEMU_STRACE",      true, handle_arg_strace,
+    {"strace",     "QEMU_STRACE",      false, handle_arg_strace,
      "",           "log system calls"},
     {"strace_logfile", "QEMU_STRACE_FILENAME", true, handle_arg_strace_logfile,
      "",           "log system calls to 'logfile' (default stderr)"},


### PR DESCRIPTION
Noticed today when ran in strace mode:

```
$ qemu-m68k-git -L /usr/m68k-unknown-linux-gnu/ -strace /tmp/a +RTS -D{s,i,w,G,g,b,S,t,p,a,l,m,z,c,r}
Error while loading +RTS: No such file or directory
```

Upstream handles options correctly:

```
$ qemu-m68k -L /usr/m68k-unknown-linux-gnu/ -strace /tmp/a +RTS -D{s,i,w,G,g,b,S,t,p,a,l,m,z,c,r}
qemu: fatal: Illegal instruction: ebc0 @ f67e36a8
```

Signed-off-by: Sergei Trofimovich siarheit@google.com
