### PR TITLE
m68k: properly sync CC_OP state in dbCC and fbCC insns

### DIFF
--- a/target-m68k/translate.c
+++ b/target-m68k/translate.c
@@ -1502,6 +1502,7 @@ DISAS_INSN(dbcc)
     base = s->pc;
     offset = (int16_t)read_im16(env, s);
     l1 = gen_new_label();
+    update_cc_op(s);
     gen_jmpcc(s, (insn >> 8) & 0xf, l1);
 
     tmp = tcg_temp_new();
@@ -1509,10 +1510,8 @@ DISAS_INSN(dbcc)
     tcg_gen_addi_i32(tmp, tmp, -1);
     gen_partset_reg(OS_WORD, reg, tmp);
     tcg_gen_brcondi_i32(TCG_COND_EQ, tmp, -1, l1);
-    update_cc_op(s);
     gen_jmp_tb(s, 1, base + offset);
     gen_set_label(l1);
-    update_cc_op(s);
     gen_jmp_tb(s, 0, s->pc);
 }
 
@@ -4794,11 +4793,10 @@ DISAS_INSN(fbcc)
     }
 
     l1 = gen_new_label();
-    gen_fjmpcc(s, insn & 0x3f, l1);
     update_cc_op(s);
+    gen_fjmpcc(s, insn & 0x3f, l1);
     gen_jmp_tb(s, 0, s->pc);
     gen_set_label(l1);
-    update_cc_op(s);
     gen_jmp_tb(s, 1, addr + offset);
 }
 


### PR DESCRIPTION
This was breaking /usr/lib/rpm/debugedit.
