### PR TITLE
Fix memfd_create error

### DIFF
--- a/configure
+++ b/configure
@@ -3920,7 +3920,7 @@ fi
 # check if memfd is supported
 memfd=no
 cat > $TMPC << EOF
-#include <sys/memfd.h>
+#include <sys/mman.h>
 
 int main(void)
 {

--- a/util/memfd.c
+++ b/util/memfd.c
@@ -31,9 +31,7 @@
 
 #include "qemu/memfd.h"
 
-#ifdef CONFIG_MEMFD
-#include <sys/memfd.h>
-#elif defined CONFIG_LINUX
+#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
 #include <sys/syscall.h>
 #include <asm/unistd.h>
 


### PR DESCRIPTION
  int memfd_create (const char *__name, unsigned int __flags) __THROW;                                                                                                                                                                         
     ^~~~~~~~~~~~                                                                                                                                                                                                                             
  CC      util/error.o                                                                                                                                                                                                                        
/home/qemu-m68k/rules.mak:66: recipe for target 'util/memfd.o' failed                                                                                                                                                               
make: *** [util/memfd.o] Error 1

Fix cross-compile error